### PR TITLE
Typecast amount before the currency format

### DIFF
--- a/src/Money/Formatter.php
+++ b/src/Money/Formatter.php
@@ -11,7 +11,7 @@ class Formatter
 {
     public function format($amount)
     {
-        $money = new Money($amount * 100, new Currency(strtoupper($this->getCurrency())));
+        $money = new Money((int) $amount * 100, new Currency(strtoupper($this->getCurrency())));
 
         $numberFormatter = new \NumberFormatter($this->getLocale(), \NumberFormatter::CURRENCY);
         $moneyFormatter  = new IntlMoneyFormatter($numberFormatter, new ISOCurrencies());

--- a/src/Money/Formatter.php
+++ b/src/Money/Formatter.php
@@ -11,7 +11,7 @@ class Formatter
 {
     public function format($amount)
     {
-        $money = new Money((int) $amount * 100, new Currency(strtoupper($this->getCurrency())));
+        $money = new Money(round($amount * 100), new Currency(strtoupper($this->getCurrency())));
 
         $numberFormatter = new \NumberFormatter($this->getLocale(), \NumberFormatter::CURRENCY);
         $moneyFormatter  = new IntlMoneyFormatter($numberFormatter, new ISOCurrencies());


### PR DESCRIPTION
Whenever I set any tax value the money formatting throws an `InvalidArgumentException` with `Amount must be an integer(ish) value`. Its is getting thrown from `vendor/moneyphp/money/src/Money.php` file within the `Money` class constructor.

For example;
`tax => 21`

Total price includes tax = 70 meaning the tax exact amount is 12.148760330579 and subtotal will be 57.851239669421. When the money formatter does times 100 it is still not a valid INT.