### PR TITLE
Adding support customizing models for custom implmentation options

### DIFF
--- a/config/shopr.php
+++ b/config/shopr.php
@@ -11,11 +11,12 @@ return [
     ],
 
     /*
-     * Create a easier way to apply custom config upon base models.
+     * The database models. You may swap these with your own models, just make sure they extend the
+     * corresponding package model rather than the standard Eloquent model.
      */
     'models' => [
-        'order' => null,
-        'orderItems' => null,
+        'Order' => Happypixels\Shopr\Models\Order::class,
+        'OrderItem' => Happypixels\Shopr\Models\OrderItem::class,
     ],
 
     /*

--- a/config/shopr.php
+++ b/config/shopr.php
@@ -11,6 +11,14 @@ return [
     ],
 
     /*
+     * Create a easier way to apply custom config upon base models.
+     */
+    'models' => [
+        'order' => null,
+        'orderItems' => null,
+    ],
+
+    /*
      * The default currency. This will affect all money formatting.
      */
     'currency' => 'USD',

--- a/src/Cart/BaseCart.php
+++ b/src/Cart/BaseCart.php
@@ -185,7 +185,7 @@ abstract class BaseCart implements Cart
             return false;
         }
 
-        $order = Order::create([
+        $order = app(Order::class)->create([
             'user_id'          => auth()->id(),
             'payment_gateway'  => $gateway,
             'payment_status'   => 'pending',

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -50,7 +50,7 @@ class Order extends Model
 
     public function items()
     {
-        return $this->hasMany(OrderItem::class);
+        return $this->hasMany(app(OrderItem::class));
     }
 
     public static function generateToken()

--- a/src/Models/OrderItem.php
+++ b/src/Models/OrderItem.php
@@ -38,7 +38,7 @@ class OrderItem extends Model
 
     public function children()
     {
-        return $this->hasMany(self::class, 'parent_id');
+        return $this->hasMany(app(self::class), 'parent_id');
     }
 
     public function shoppable()

--- a/src/Routes/web.php
+++ b/src/Routes/web.php
@@ -22,7 +22,8 @@ Route::group(['middleware' => $middleware], function () {
     // Order confirmation.
     if (config('shopr.templates.order-confirmation')) {
         Route::get('order-confirmation', function () {
-            $order = Happypixels\Shopr\Models\Order::with('items')
+            $order = app(Happypixels\Shopr\Models\Order::class)
+                ->with('items')
                 ->where('token', request('token'))
                 ->where('payment_status', 'paid')
                 ->firstOrFail();

--- a/src/ShoprServiceProvider.php
+++ b/src/ShoprServiceProvider.php
@@ -54,12 +54,12 @@ class ShoprServiceProvider extends ServiceProvider
     {
         $this->app->bind(Cart::class, SessionCartRepository::class);
 
-        if (config('shopr.models.order')) {
-            $this->app->singleton(Order::class, config('shopr.models.order'));
+        if (config('shopr.models.Order')) {
+            $this->app->singleton(Order::class, config('shopr.models.Order'));
         }
 
-        if (config('shopr.models.orderItems')) {
-            $this->app->singleton(OrderItem::class, config('shopr.models.orderItems'));
+        if (config('shopr.models.OrderItem')) {
+            $this->app->singleton(OrderItem::class, config('shopr.models.OrderItem'));
         }
     }
 

--- a/src/ShoprServiceProvider.php
+++ b/src/ShoprServiceProvider.php
@@ -5,6 +5,7 @@ namespace Happypixels\Shopr;
 use Happypixels\Shopr\Models\Order;
 use Happypixels\Shopr\Contracts\Cart;
 use Illuminate\Support\Facades\Event;
+use Happypixels\Shopr\Models\OrderItem;
 use Illuminate\Support\ServiceProvider;
 use Happypixels\Shopr\Observers\OrderObserver;
 use Happypixels\Shopr\Repositories\SessionCartRepository;
@@ -52,6 +53,14 @@ class ShoprServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->bind(Cart::class, SessionCartRepository::class);
+
+        if (config('shopr.models.order')) {
+            $this->app->singleton(Order::class, config('shopr.models.order'));
+        }
+
+        if (config('shopr.models.orderItems')) {
+            $this->app->singleton(OrderItem::class, config('shopr.models.orderItems'));
+        }
     }
 
     /**


### PR DESCRIPTION
I'd like to extend the Order and OrderItem models with missing columns(notes, payment_url etc.) and use it in my own way.
By leveraging the Application Container we can easily extend the base but leaving the cart -> order creation intact as is. Even the relationships will use the extended model

Models can easily extend as such:
```
class Order extends ShoprOrder {
// adding more stuff onto it
}

class OrderItem extends ShoprOrderItem {
// adding stuff
}
```
but don't forgot the configure the proper models:
```
'models' => [
    'order' => App\Models\Order::class,
    'orderItem' => App\Models\OrderItem::class,
],
```
And in case you only extend the `Order` class leave `orderItem` empty and it still works as it should.
```
'models' => [
    'order' => App\Models\Order::class,
    'orderItem' => null,
],
```