### PR TITLE
Fix ICU version in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,41 @@
 language: php
 
-php:
-  - 7.1
-  - 7.2
-  - 7.3
+matrix:
+    include:
+        - php: 7.1
+        - php: 7.2
+        - php: 7.3
+          env: ICU_VERSION=63.1
 
 before_install:
   - sudo apt-get update
   - travis_retry composer self-update
+  - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then echo yes | pecl install -f apcu_bc-1.0.4; fi
+  - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then echo yes | pecl install -f apcu-5.1.11; fi
+  - |
+      if [[ $ICU_VERSION ]]; then
+        ICU_DIR=$HOME/.build/icu-$ICU_VERSION
+        ICU_PHP_VERSION=$(php -r "echo PHP_VERSION;")
+        ICU_PHP_DIR=$HOME/.build/php-$ICU_PHP_VERSION-icu-$ICU_VERSION
+        export ICU_PHP=$ICU_PHP_DIR/bin/php
+        if [ ! -f $ICU_PHP ]; then
+            wget -O icu-src.tgz http://download.icu-project.org/files/icu4c/$ICU_VERSION/icu4c-$(echo $ICU_VERSION | tr '.' '_')-src.tgz
+            mkdir icu-src && tar xzf icu-src.tgz -C icu-src --strip-components=1
+            pushd icu-src/source
+                ./configure --prefix=$ICU_DIR
+                make && make install
+            popd
+            wget -O php-src.tgz http://us1.php.net/get/php-$ICU_PHP_VERSION.tar.gz/from/this/mirror
+            mkdir php-src && tar xzf php-src.tgz -C php-src --strip-components=1
+            pushd php-src
+                ./configure --prefix=$ICU_PHP_DIR --enable-intl --with-icu-dir=$ICU_DIR
+                make && make install
+            popd
+        fi
+        $ICU_PHP -r "echo INTL_ICU_VERSION.PHP_EOL;"
+        $ICU_PHP -r "var_dump((new ReflectionClass('Normalizer'))->getConstants());"
+      fi
+  - php -i
 
 install:
   - travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 dist: xenial
 language: php
 
+env:
+  global:
+    - ICU_VERSION=60.2
+
 matrix:
     include:
         - php: 7.1
         - php: 7.2
-          env: ICU_VERSION=60.2
         - php: 7.3
-          env: ICU_VERSION=63.1
 
 services:
   - mysql
@@ -46,7 +48,6 @@ install:
   - travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest
 
 script:
-  - vendor/bin/phpunit
   - if [[ $ICU_PHP ]]; then $ICU_PHP ./vendor/bin/phpunit; fi
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,30 @@ php:
 before_install:
   - sudo apt-get update
   - travis_retry composer self-update
+  - |
+      ICU_DIR=$HOME/.build/icu-63.1
+      ICU_PHP_VERSION=$(php -r "echo PHP_VERSION;")
+      ICU_PHP_DIR=$HOME/.build/php-$ICU_PHP_VERSION-icu-63.1
+      export ICU_PHP=$ICU_PHP_DIR/bin/php
+      if [ ! -f $ICU_PHP ]; then
+          wget -O icu-src.tgz http://download.icu-project.org/files/icu4c/63.1/icu4c-$(echo 63.1 | tr '.' '_')-src.tgz
+          mkdir icu-src && tar xzf icu-src.tgz -C icu-src --strip-components=1
+          pushd icu-src/source
+              ./configure --prefix=$ICU_DIR
+              make && make install
+          popd
+          wget -O php-src.tgz http://us1.php.net/get/php-$ICU_PHP_VERSION.tar.gz/from/this/mirror
+          mkdir php-src && tar xzf php-src.tgz -C php-src --strip-components=1
+          pushd php-src
+              ./configure --prefix=$ICU_PHP_DIR --enable-intl --with-icu-dir=$ICU_DIR
+              make && make install
+          popd
+      fi
+      $ICU_PHP -r "echo INTL_ICU_VERSION.PHP_EOL;"
+      $ICU_PHP -r "var_dump((new ReflectionClass('Normalizer'))->getConstants());"
 
 install:
   - travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest
-  - git -C /tmp clone https://gist.github.com/siffash/76676186de0ffc6eb6cbf89abc7a5e2f icu-install
-  - sudo chmod +x /tmp/icu-install/icu-install.sh
-  - sudo /tmp/icu-install/icu-install.sh install 60.2
-  - rm -rf /tmp/icu-install
 
 script:
   - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ php:
 
 before_install:
   - sudo apt-get update
+  - git -C /tmp clone https://gist.github.com/siffash/76676186de0ffc6eb6cbf89abc7a5e2f icu-install
+  - /tmp/icu-install/icu-install.sh install 60.2
+  - rm -rf /tmp/icu-install
   - travis_retry composer self-update
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ php:
 
 before_install:
   - sudo apt-get update
-  - git -C /tmp clone https://gist.github.com/siffash/76676186de0ffc6eb6cbf89abc7a5e2f icu-install
-  - sudo chmod +x /tmp/icu-install/icu-install.sh
-  - sudo /tmp/icu-install/icu-install.sh install 60.2
-  - rm -rf /tmp/icu-install
   - travis_retry composer self-update
 
 install:
   - travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest
+  - git -C /tmp clone https://gist.github.com/siffash/76676186de0ffc6eb6cbf89abc7a5e2f icu-install
+  - sudo chmod +x /tmp/icu-install/icu-install.sh
+  - sudo /tmp/icu-install/icu-install.sh install 60.2
+  - rm -rf /tmp/icu-install
 
 script:
   - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
+dist: xenial
 language: php
 
 matrix:
     include:
         - php: 7.1
-          env: ICU_VERSION=56.1
         - php: 7.2
           env: ICU_VERSION=60.2
         - php: 7.3
           env: ICU_VERSION=63.1
+
+services:
+  - mysql
 
 before_install:
   - sudo apt-get update
@@ -43,7 +46,8 @@ install:
   - travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest
 
 script:
-  - $ICU_PHP vendor/bin/phpunit
+  - vendor/bin/phpunit
+  - if [[ $ICU_PHP ]]; then $ICU_PHP ./vendor/bin/phpunit; fi
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: php
 matrix:
     include:
         - php: 7.1
+          env: ICU_VERSION=56.1
         - php: 7.2
+          env: ICU_VERSION=60.2
         - php: 7.3
           env: ICU_VERSION=63.1
 
@@ -41,7 +43,7 @@ install:
   - travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest
 
 script:
-  - vendor/bin/phpunit
+  - $ICU_PHP vendor/bin/phpunit
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ php:
 before_install:
   - sudo apt-get update
   - git -C /tmp clone https://gist.github.com/siffash/76676186de0ffc6eb6cbf89abc7a5e2f icu-install
-  - /tmp/icu-install/icu-install.sh install 60.2
+  - sudo chmod +x /tmp/icu-install/icu-install.sh
+  - sudo /tmp/icu-install/icu-install.sh install 60.2
   - rm -rf /tmp/icu-install
   - travis_retry composer self-update
 

--- a/config/shopr.php
+++ b/config/shopr.php
@@ -24,7 +24,7 @@ return [
      */
     'currency' => 'USD',
 
-    /**
+    /*
      * The money formatter class. You may provide your own class here, just make sure it extends
      * the default Happypixels\Shopr\Money\Formatter class.
      */

--- a/config/shopr.php
+++ b/config/shopr.php
@@ -24,6 +24,12 @@ return [
      */
     'currency' => 'USD',
 
+    /**
+     * The money formatter class. You may provide your own class here, just make sure it extends
+     * the default Happypixels\Shopr\Money\Formatter class.
+     */
+    'money_formatter' => Happypixels\Shopr\Money\Formatter::class,
+
     /*
      * The tax percentage.
      */

--- a/src/Cart/BaseCart.php
+++ b/src/Cart/BaseCart.php
@@ -64,7 +64,7 @@ abstract class BaseCart implements Cart
         $subTotal = $this->subTotal();
         $taxTotal = $this->taxTotal();
         $total = $this->total();
-        $formatter = new Formatter;
+        $formatter = app(Formatter::class);
 
         return [
             'items' => $this->items(),

--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -79,7 +79,7 @@ class CartItem
 
     public function refreshDiscountValue()
     {
-        if (!$this->shoppable->isDiscount() || $this->shoppable->is_fixed) {
+        if (! $this->shoppable->isDiscount() || $this->shoppable->is_fixed) {
             return;
         }
 

--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -34,7 +34,7 @@ class CartItem
         $this->options = $options;
         $this->subItems = $this->addSubItems($subItems);
         $this->price = ($price) ?? $this->shoppable->getPrice();
-        $this->price_formatted = (new Formatter)->format($this->price);
+        $this->price_formatted = app(Formatter::class)->format($this->price);
         $this->total = $this->total();
     }
 
@@ -86,7 +86,7 @@ class CartItem
         $value = $this->shoppable->getPrice();
 
         $this->price = $value;
-        $this->price_formatted = (new Formatter)->format($value);
+        $this->price_formatted = app(Formatter::class)->format($value);
         $this->total = $this->total();
     }
 }

--- a/src/CartSubItem.php
+++ b/src/CartSubItem.php
@@ -28,7 +28,7 @@ class CartSubItem
         $this->quantity = $quantity;
         $this->options = $options;
         $this->price = (is_numeric($price)) ? $price : $this->shoppable->getPrice();
-        $this->price_formatted = (new Formatter)->format($this->price);
+        $this->price_formatted = app(Formatter::class)->format($this->price);
         $this->total = $this->total();
     }
 

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -35,17 +35,17 @@ class Order extends Model
 
     public function getTotalFormattedAttribute()
     {
-        return (new Formatter)->format($this->total);
+        return app(Formatter::class)->format($this->total);
     }
 
     public function getSubTotalFormattedAttribute()
     {
-        return (new Formatter)->format($this->sub_total);
+        return app(Formatter::class)->format($this->sub_total);
     }
 
     public function getTaxFormattedAttribute()
     {
-        return (new Formatter)->format($this->tax);
+        return app(Formatter::class)->format($this->tax);
     }
 
     public function items()

--- a/src/Models/OrderItem.php
+++ b/src/Models/OrderItem.php
@@ -28,12 +28,12 @@ class OrderItem extends Model
 
     public function getPriceFormattedAttribute()
     {
-        return (new Formatter)->format($this->price);
+        return app(Formatter::class)->format($this->price);
     }
 
     public function getTotalFormattedAttribute()
     {
-        return (new Formatter)->format($this->price * $this->quantity);
+        return app(Formatter::class)->format($this->price * $this->quantity);
     }
 
     public function children()

--- a/src/Money/Formatter.php
+++ b/src/Money/Formatter.php
@@ -124,8 +124,9 @@ class Formatter
      */
     public function applyDecimalCount()
     {
-        if ($this->decimalCount) {
+        if ($this->decimalCount !== null) {
             $this->formatter->setAttribute(NumberFormatter::MIN_FRACTION_DIGITS, $this->decimalCount);
+            $this->formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $this->decimalCount);
         }
 
         return $this;

--- a/src/Money/Formatter.php
+++ b/src/Money/Formatter.php
@@ -4,28 +4,215 @@ namespace Happypixels\Shopr\Money;
 
 use Money\Money;
 use Money\Currency;
+use \NumberFormatter;
 use Money\Currencies\ISOCurrencies;
 use Money\Formatter\IntlMoneyFormatter;
 
 class Formatter
 {
-    public function format($amount)
+    /**
+     * The decimal separator symbol.
+     *
+     * @var string
+     */
+    public $decimalSeparator;
+
+    /**
+     * The amount of decimals.
+     *
+     * @var int
+     */
+    public $decimalCount;
+
+    /**
+     * The default symbol to be used.
+     *
+     * @var string
+     */
+    public $symbol;
+
+    /**
+     * A forced symbol to add before the amount.
+     *
+     * @var string
+     */
+    public $symbolBefore;
+
+    /**
+     * The thousand separator symbol.
+     *
+     * @var string
+     */
+    public $thousandSeparator;
+
+    /**
+     * The formatter.
+     *
+     * @var NumberFormatter
+     */
+    protected $formatter;
+
+    /**
+     * The amount undergoing formatting.
+     *
+     * @var mixed
+     */
+    protected $amount;
+
+    /**
+     * Create the default formatter.
+     */
+    public function __construct()
     {
-        $money = new Money(round($amount * 100), new Currency(strtoupper($this->getCurrency())));
-
-        $numberFormatter = new \NumberFormatter($this->getLocale(), \NumberFormatter::CURRENCY);
-        $moneyFormatter = new IntlMoneyFormatter($numberFormatter, new ISOCurrencies());
-
-        return $moneyFormatter->format($money);
+        $this->formatter = new NumberFormatter($this->getLocale(), NumberFormatter::CURRENCY);
     }
 
+    /**
+     * Format the amount into a human readable currency value.
+     *
+     * @return string
+     */
+    public function format($amount)
+    {
+        $this->amount = $amount;
+
+        return $this->applySymbol()
+            ->applyThousandSeparator()
+            ->applyDecimalSeparator()
+            ->applyDecimalCount()
+            ->formatAmount()
+            ->cleanUp()
+            ->applySymbolBefore()
+            ->getResult();
+    }
+
+    /**
+     * Apply a custom symbol to the formatting.
+     *
+     * @return self
+     */
+    public function applySymbol()
+    {
+        if ($this->symbol !== null) {
+            $this->formatter->setSymbol(NumberFormatter::CURRENCY_SYMBOL, $this->symbol);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Apply a custom thousand separator to the formatting.
+     *
+     * @return self
+     */
+    public function applyThousandSeparator()
+    {
+        if ($this->thousandSeparator) {
+            $this->formatter->setSymbol(
+                NumberFormatter::MONETARY_GROUPING_SEPARATOR_SYMBOL,
+                $this->thousandSeparator
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Apply a specific decimal count.
+     *
+     * @return self
+     */
+    public function applyDecimalCount()
+    {
+        if ($this->decimalCount) {
+            $this->formatter->setAttribute(NumberFormatter::MIN_FRACTION_DIGITS, $this->decimalCount);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Apply a custom decimal separator to the formatting.
+     *
+     * @return self
+     */
+    public function applyDecimalSeparator()
+    {
+        if ($this->decimalSeparator) {
+            $this->formatter->setSymbol(
+                NumberFormatter::MONETARY_SEPARATOR_SYMBOL,
+                $this->decimalSeparator
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns the formatted amount.
+     *
+     * @return string
+     */
+    protected function getResult()
+    {
+        return $this->amount;
+    }
+
+    /**
+     * Runs the PHP NumberFormatter on the amount.
+     *
+     * @return string
+     */
+    protected function formatAmount()
+    {
+        $this->amount = (new IntlMoneyFormatter($this->formatter, new ISOCurrencies()))->format(
+            new Money(round($this->amount * 100), new Currency($this->getCurrency()))
+        );
+
+        return $this;
+    }
+
+    /**
+     * Applies a symbol before, if specified.
+     *
+     * @return string
+     */
+    protected function applySymbolBefore()
+    {
+        $this->amount = $this->symbolBefore.$this->amount;
+
+        return $this;
+    }
+
+    /**
+     * Cleans up unexpected characters and spaces returned by NumberFormatter for some reason.
+     *
+     * @return string
+     */
+    protected function cleanUp()
+    {
+        $this->amount = trim(str_replace(' ', ' ', $this->amount));
+
+        return $this;
+    }
+
+    /**
+     * Returns the current locale.
+     *
+     * @return string
+     */
     protected function getLocale()
     {
         return app()->getLocale() ?? 'en';
     }
 
+    /**
+     * Returns the current currency code.
+     *
+     * @return string
+     */
     protected function getCurrency()
     {
-        return config('shopr.currency') ?? 'USD';
+        return config('shopr.currency') ? strtoupper(config('shopr.currency')) : 'USD';
     }
 }

--- a/src/Money/Formatter.php
+++ b/src/Money/Formatter.php
@@ -4,7 +4,7 @@ namespace Happypixels\Shopr\Money;
 
 use Money\Money;
 use Money\Currency;
-use \NumberFormatter;
+use NumberFormatter;
 use Money\Currencies\ISOCurrencies;
 use Money\Formatter\IntlMoneyFormatter;
 

--- a/src/Money/Formatter.php
+++ b/src/Money/Formatter.php
@@ -89,7 +89,7 @@ class Formatter
             ->applyDecimalSeparator()
             ->applyDecimalCount()
             ->formatAmount()
-            ->cleanUp()
+            ->removeUnwantedWhitespace()
             ->applySymbolPosition()
             ->getResult();
     }
@@ -206,13 +206,21 @@ class Formatter
     }
 
     /**
-     * Cleans up unexpected characters and spaces returned by NumberFormatter for some reason.
+     * Removes unwanted whitespace in the amount.
      *
      * @return self
      */
-    protected function cleanUp()
+    protected function removeUnwantedWhitespace()
     {
+        // Remove unprintable spaces created by NumberFormatter for some reason.
         $this->amount = trim(str_replace(' ', ' ', $this->amount));
+
+        // Remove unwanted whitespace around the symbol.
+        $this->amount = str_replace(
+            [$this->assignedSymbol.' ', ' '.$this->assignedSymbol],
+            $this->assignedSymbol,
+            $this->amount
+        );
 
         return $this;
     }

--- a/src/ShoprServiceProvider.php
+++ b/src/ShoprServiceProvider.php
@@ -5,6 +5,7 @@ namespace Happypixels\Shopr;
 use Happypixels\Shopr\Models\Order;
 use Happypixels\Shopr\Contracts\Cart;
 use Illuminate\Support\Facades\Event;
+use Happypixels\Shopr\Money\Formatter;
 use Happypixels\Shopr\Models\OrderItem;
 use Illuminate\Support\ServiceProvider;
 use Happypixels\Shopr\Observers\OrderObserver;
@@ -60,6 +61,10 @@ class ShoprServiceProvider extends ServiceProvider
 
         if (config('shopr.models.OrderItem')) {
             $this->app->singleton(OrderItem::class, config('shopr.models.OrderItem'));
+        }
+
+        if (config('shopr.money_formatter')) {
+            $this->app->singleton(Formatter::class, config('shopr.money_formatter'));
         }
     }
 

--- a/tests/Feature/Money/PriceFormattingTest.php
+++ b/tests/Feature/Money/PriceFormattingTest.php
@@ -7,7 +7,7 @@ use Happypixels\Shopr\Contracts\Cart;
 use Happypixels\Shopr\Tests\TestCase;
 use Happypixels\Shopr\Tests\Support\Models\TestShoppable;
 
-class FormatterTest extends TestCase
+class PriceFormattingTest extends TestCase
 {
     /** @test */
     public function it_formats_order_amounts()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -64,14 +64,6 @@ class TestCase extends Orchestra
         return $cart->addItem(get_class($model), 1, 1);
     }
 
-    public function mock($class)
-    {
-        $mock = Mockery::mock($class);
-        $this->app->instance($class, $mock);
-
-        return $mock;
-    }
-
     /**
      * Define environment setup.
      *

--- a/tests/Unit/Money/DefaultFormatterTest.php
+++ b/tests/Unit/Money/DefaultFormatterTest.php
@@ -18,12 +18,6 @@ class DefaultFormatterTest extends TestCase
     }
 
     /** @test */
-    public function verify_icu()
-    {
-        echo defined('INTL_ICU_VERSION') ? 'ICU Version: '.INTL_ICU_VERSION : 'no ICU';
-    }
-
-    /** @test */
     public function it_defaults_to_chosen_currency_standards()
     {
         $this->assertEquals('$25.00', $this->formatter->format('25'));

--- a/tests/Unit/Money/DefaultFormatterTest.php
+++ b/tests/Unit/Money/DefaultFormatterTest.php
@@ -56,6 +56,11 @@ class DefaultFormatterTest extends TestCase
         $formatter->decimalCount = 4;
 
         $this->assertEquals('25,5000 kr', $formatter->format(25.5));
+
+        $formatter = app(config('shopr.money_formatter'));
+        $formatter->decimalCount = 0;
+
+        $this->assertEquals('26 kr', $formatter->format(25.5));
     }
 
     /** @test */

--- a/tests/Unit/Money/DefaultFormatterTest.php
+++ b/tests/Unit/Money/DefaultFormatterTest.php
@@ -28,7 +28,7 @@ class DefaultFormatterTest extends TestCase
     {
         $this->formatter->symbol = 'kr';
 
-        $this->assertEquals('kr 25.00', $this->formatter->format(25));
+        $this->assertEquals('kr25.00', $this->formatter->format(25));
     }
 
     /** @test */

--- a/tests/Unit/Money/DefaultFormatterTest.php
+++ b/tests/Unit/Money/DefaultFormatterTest.php
@@ -6,93 +6,81 @@ use Happypixels\Shopr\Tests\TestCase;
 
 class DefaultFormatterTest extends TestCase
 {
+    protected $formatter;
+
     public function setUp()
     {
         parent::setUp();
 
-        app()->setLocale('sv_SE');
-        config(['shopr.currency' => 'SEK']);
+        app()->setLocale('en_US');
+        config(['shopr.currency' => 'USD']);
+        $this->formatter = app(config('shopr.money_formatter'));
     }
 
     /** @test */
     public function it_defaults_to_chosen_currency_standards()
     {
-        $formatter = app(config('shopr.money_formatter'));
-
-        $this->assertEquals('25,00 kr', $formatter->format('25'));
+        $this->assertEquals('$25.00', $this->formatter->format('25'));
     }
 
     /** @test */
     public function symbol_is_customizable()
     {
-        $formatter = app(config('shopr.money_formatter'));
-        $formatter->symbol = 'USD';
+        $this->formatter->symbol = 'kr';
 
-        $this->assertEquals('25,00 USD', $formatter->format(25));
+        $this->assertEquals('kr 25.00', $this->formatter->format(25));
     }
 
     /** @test */
     public function symbol_is_removable()
     {
-        $formatter = app(config('shopr.money_formatter'));
-        $formatter->symbol = false;
+        $this->formatter->symbol = false;
 
-        $this->assertEquals('25,00', $formatter->format(25));
+        $this->assertEquals('25.00', $this->formatter->format(25));
     }
 
     /** @test */
     public function symbol_position_is_customizable()
     {
-        $formatter = app(config('shopr.money_formatter'));
-
-        $this->assertEquals('25,00 kr', $formatter->format(25));
-
         // Using the default symbol.
-        $formatter->symbolPosition = 'before';
-        $this->assertEquals('kr25,00', $formatter->format(25));
+        $this->formatter->symbolPosition = 'after';
+        $this->assertEquals('25.00$', $this->formatter->format(25));
 
-        $formatter->symbolPosition = 'after';
-        $this->assertEquals('25,00kr', $formatter->format(25));
+        $this->formatter->symbolPosition = 'before';
+        $this->assertEquals('$25.00', $this->formatter->format(25));
 
         // Using a custom symbol.
-        $formatter->symbol = '¢';
-        $this->assertEquals('25,00¢', $formatter->format(25));
+        $this->formatter->symbol = '¢';
+        $this->assertEquals('¢25.00', $this->formatter->format(25));
 
-        $formatter->symbolPosition = 'before';
-        $this->assertEquals('¢25,00', $formatter->format(25));
+        $this->formatter->symbolPosition = 'after';
+        $this->assertEquals('25.00¢', $this->formatter->format(25));
     }
 
     /** @test */
     public function thousand_separator_is_customizable()
     {
-        $formatter = app(config('shopr.money_formatter'));
-        $formatter->thousandSeparator = '-';
+        $this->formatter->thousandSeparator = '-';
 
-        $this->assertEquals('25-000-000,00 kr', $formatter->format(25000000));
+        $this->assertEquals('$25-000-000.00', $this->formatter->format(25000000));
     }
 
     /** @test */
     public function decimal_count_is_customizable()
     {
-        $formatter = app(config('shopr.money_formatter'));
-        $formatter->decimalCount = 4;
+        $this->formatter->decimalCount = 4;
+        $this->assertEquals('$25.5000', $this->formatter->format(25.5));
 
-        $this->assertEquals('25,5000 kr', $formatter->format(25.5));
-
-        $formatter = app(config('shopr.money_formatter'));
-        $formatter->decimalCount = 0;
-
-        $this->assertEquals('26 kr', $formatter->format(25.5));
+        $this->formatter->decimalCount = 0;
+        $this->assertEquals('$26', $this->formatter->format(25.5));
     }
 
     /** @test */
-    public function decimal_symbol_is_customizable()
+    public function decimal_separator_is_customizable()
     {
-        // Swedish.
-        $formatter = app(config('shopr.money_formatter'));
-        $formatter->decimalSeparator = '^';
+        $this->formatter->decimalSeparator = '^';
 
-        $this->assertEquals('25^50 kr', $formatter->format(25.5));
+        $this->assertEquals('$25^50', $this->formatter->format(25.5));
     }
 
     /** @test */
@@ -103,8 +91,8 @@ class DefaultFormatterTest extends TestCase
         $formatter->symbol = 'SYM';
         $formatter->decimalCount = 4;
         $formatter->thousandSeparator = '-';
-        $formatter->symbolPosition = 'before';
+        $formatter->symbolPosition = 'after';
 
-        $this->assertEquals('SYM25-000-000^5000', $formatter->format(25000000.5));
+        $this->assertEquals('25-000-000^5000SYM', $formatter->format(25000000.5));
     }
 }

--- a/tests/Unit/Money/DefaultFormatterTest.php
+++ b/tests/Unit/Money/DefaultFormatterTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Happypixels\Shopr\Tests\Feature\Unit;
+
+use Happypixels\Shopr\Tests\TestCase;
+
+class DefaultFormatterTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        app()->setLocale('sv_SE');
+        config(['shopr.currency' => 'SEK']);
+    }
+
+    /** @test */
+    public function it_defaults_to_chosen_currency_standards()
+    {
+        $formatter = app(config('shopr.money_formatter'));
+
+        $this->assertEquals('25,00 kr', $formatter->format('25'));
+    }
+
+    /** @test */
+    public function symbol_is_customizable()
+    {
+        $formatter = app(config('shopr.money_formatter'));
+        $formatter->symbol = 'USD';
+
+        $this->assertEquals('25,00 USD', $formatter->format(25));
+    }
+
+    /** @test */
+    public function symbol_is_removable()
+    {
+        $formatter = app(config('shopr.money_formatter'));
+        $formatter->symbol = false;
+
+        $this->assertEquals('25,00', $formatter->format(25));
+    }
+
+    /** @test */
+    public function thousand_separator_is_customizable()
+    {
+        $formatter = app(config('shopr.money_formatter'));
+        $formatter->thousandSeparator = '-';
+
+        $this->assertEquals('25-000-000,00 kr', $formatter->format(25000000));
+    }
+
+    /** @test */
+    public function decimal_count_is_customizable()
+    {
+        $formatter = app(config('shopr.money_formatter'));
+        $formatter->decimalCount = 4;
+
+        $this->assertEquals('25,5000 kr', $formatter->format(25.5));
+    }
+
+    /** @test */
+    public function symbol_before_is_customizable()
+    {
+        // Swedish.
+        $formatter = app(config('shopr.money_formatter'));
+        $formatter->symbolBefore = '~ ';
+
+        $this->assertEquals('~ 25,50 kr', $formatter->format(25.5));
+    }
+
+    /** @test */
+    public function decimal_symbol_is_customizable()
+    {
+        // Swedish.
+        $formatter = app(config('shopr.money_formatter'));
+        $formatter->decimalSeparator = '^';
+
+        $this->assertEquals('25^50 kr', $formatter->format(25.5));
+    }
+
+    /** @test */
+    public function it_combines_the_settings()
+    {
+        $formatter = app(config('shopr.money_formatter'));
+        $formatter->decimalSeparator = '^';
+        $formatter->symbol = 'SYM';
+        $formatter->decimalCount = 4;
+        $formatter->thousandSeparator = '-';
+        $formatter->symbolBefore = '~ ';
+
+        $this->assertEquals('~ 25-000-000^5000 SYM', $formatter->format(25000000.5));
+    }
+}

--- a/tests/Unit/Money/DefaultFormatterTest.php
+++ b/tests/Unit/Money/DefaultFormatterTest.php
@@ -18,6 +18,12 @@ class DefaultFormatterTest extends TestCase
     }
 
     /** @test */
+    public function verify_icu()
+    {
+        echo defined('INTL_ICU_VERSION') ? 'ICU Version: '.INTL_ICU_VERSION : 'no ICU';
+    }
+
+    /** @test */
     public function it_defaults_to_chosen_currency_standards()
     {
         $this->assertEquals('$25.00', $this->formatter->format('25'));

--- a/tests/Unit/Money/DefaultFormatterTest.php
+++ b/tests/Unit/Money/DefaultFormatterTest.php
@@ -41,6 +41,28 @@ class DefaultFormatterTest extends TestCase
     }
 
     /** @test */
+    public function symbol_position_is_customizable()
+    {
+        $formatter = app(config('shopr.money_formatter'));
+
+        $this->assertEquals('25,00 kr', $formatter->format(25));
+
+        // Using the default symbol.
+        $formatter->symbolPosition = 'before';
+        $this->assertEquals('kr25,00', $formatter->format(25));
+
+        $formatter->symbolPosition = 'after';
+        $this->assertEquals('25,00kr', $formatter->format(25));
+
+        // Using a custom symbol.
+        $formatter->symbol = '¢';
+        $this->assertEquals('25,00¢', $formatter->format(25));
+
+        $formatter->symbolPosition = 'before';
+        $this->assertEquals('¢25,00', $formatter->format(25));
+    }
+
+    /** @test */
     public function thousand_separator_is_customizable()
     {
         $formatter = app(config('shopr.money_formatter'));
@@ -64,16 +86,6 @@ class DefaultFormatterTest extends TestCase
     }
 
     /** @test */
-    public function symbol_before_is_customizable()
-    {
-        // Swedish.
-        $formatter = app(config('shopr.money_formatter'));
-        $formatter->symbolBefore = '~ ';
-
-        $this->assertEquals('~ 25,50 kr', $formatter->format(25.5));
-    }
-
-    /** @test */
     public function decimal_symbol_is_customizable()
     {
         // Swedish.
@@ -91,8 +103,8 @@ class DefaultFormatterTest extends TestCase
         $formatter->symbol = 'SYM';
         $formatter->decimalCount = 4;
         $formatter->thousandSeparator = '-';
-        $formatter->symbolBefore = '~ ';
+        $formatter->symbolPosition = 'before';
 
-        $this->assertEquals('~ 25-000-000^5000 SYM', $formatter->format(25000000.5));
+        $this->assertEquals('SYM25-000-000^5000', $formatter->format(25000000.5));
     }
 }


### PR DESCRIPTION
Travis comes with an outdated ICU version, causing tests related to the money formatter to fail. This PR aims at solving the problem by manually installing a newer version of ICU on the Travis machines.